### PR TITLE
Remove numberOfCopies, neededBy from sierra hold-request

### DIFF
--- a/lib/on_site_hold_request.rb
+++ b/lib/on_site_hold_request.rb
@@ -97,7 +97,12 @@ class OnSiteHoldRequest
       'recordNumber' => @data['record'],
       'pickupLocation' => pickup_location
     }
-    hold['neededBy'] = @data['neededBy'] unless @data['neededBy'].nil?
+    # TODO: Sierra complains about json formatting if `neededBy` doesn't match
+    # "ISO 8601 format (yyyy-MM-dd)", so we should reduce precision of
+    # `neededBy` when time info is included.
+    # For now, we'll just disable it because it's not set to anything
+    # meaningful right now.
+    # hold['neededBy'] = @data['neededBy'] unless @data['neededBy'].nil?
 
     # See https://sandbox.iii.com/iii/sierra-api/swagger/index.html#!/patrons/Place_a_new_hold_request_post_24
     $logger.debug "self.sierra_client.post \"patrons/#{patron_id}/holds/requests\", #{hold.to_json}"

--- a/lib/on_site_hold_request.rb
+++ b/lib/on_site_hold_request.rb
@@ -98,7 +98,6 @@ class OnSiteHoldRequest
       'pickupLocation' => pickup_location
     }
     hold['neededBy'] = @data['neededBy'] unless @data['neededBy'].nil?
-    hold['numberOfCopies'] = @data['numberOfCopies'] unless @data['numberOfCopies'].nil?
 
     # See https://sandbox.iii.com/iii/sierra-api/swagger/index.html#!/patrons/Place_a_new_hold_request_post_24
     $logger.debug "self.sierra_client.post \"patrons/#{patron_id}/holds/requests\", #{hold.to_json}"


### PR DESCRIPTION
This is a couple of hotfixes made on qa which we need to sync down to development.

Using `numberOfCopies` seems to have triggered an error placing holds in the Sierra api even though it was always `1`, (which I assume is the default if it's left off).

Using `neededBy` was never essential to the hold-request workflow because it's not initialized to anything meaningful. It looks like upstream components may sometimes generate date strings with time information, which the Sierra API rejects. So let's just remove the property outright until we can down-precision it properly with the right timezone handling.