### PR TITLE
SCC-2212: Send email for duplicate hold with note

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -53,20 +53,15 @@ def handle_create_hold_request(event)
 
   $logger.debug "OnSiteHoldRequest.create #{params.to_json}"
 
-  begin
-    OnSiteHoldRequest.create params
-    {
-      statusCode: 201,
-      message: "Hold created"
-    }
-  rescue SierraHoldAlreadyCreatedError => e
-    # Sierra reports the hold has already been reported. Indicate success, but
-    # differentiate from 201 created response.
-    {
-      statusCode: 200,
-      message: "Hold already created"
-    }
-  end
+  response = OnSiteHoldRequest.create params
+
+  response.is_duplicate? ? {
+    statusCode: 200,
+    message: "Hold already created"
+  } : {
+    statusCode: 201,
+    message: "Hold created"
+  }
 end
 
 def parse_body(event)

--- a/email/lib_answers_email.html.erb
+++ b/email/lib_answers_email.html.erb
@@ -1,6 +1,10 @@
 <%= email_header %>
 
-<%= <p> duplicate_text </p> if @duplicate %>
+<% if @duplicate %>
+  <p>
+    <%= duplicate_text %>
+  </p>
+<% end %>
 
 <table>
 <%

--- a/email/lib_answers_email.html.erb
+++ b/email/lib_answers_email.html.erb
@@ -1,6 +1,6 @@
 <%= email_header %>
 
-<%= duplicate_text %>
+<%= <p> duplicate_text </p> if @duplicate %>
 
 <table>
 <%

--- a/email/lib_answers_email.html.erb
+++ b/email/lib_answers_email.html.erb
@@ -1,5 +1,7 @@
 <%= email_header %>
 
+<%= duplicate_text %>
+
 <table>
 <%
   @email_data.each do |(category, properties)|

--- a/email/lib_answers_email.text.erb
+++ b/email/lib_answers_email.text.erb
@@ -1,5 +1,7 @@
 <%= email_header %>
 
+<%= duplicate_text %>
+
 <%
   @email_data.each do |(category, properties)|
 %>

--- a/lib/lib_answers_email.rb
+++ b/lib/lib_answers_email.rb
@@ -71,6 +71,11 @@ class LibAnswersEmail
       (is_sierra_test? ? 'SCC Training/QA' : 'Production SCC')
   end
 
+  def duplicate_text
+    return nil unless @hold_request.is_duplicate?
+    'Patron has made this EDD request for an item they already have on hold.'
+  end
+
   ##
   # Get relevant SCC domain
   def scc_domain

--- a/lib/lib_answers_email.rb
+++ b/lib/lib_answers_email.rb
@@ -62,6 +62,7 @@ class LibAnswersEmail
         "Requested On" => Time.new.strftime('%A %B %d, %I:%M%P ET')
       }
     }
+    @duplicate = @hold_request.is_duplicate?
   end
 
   def email_header

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -33,6 +33,13 @@ describe :app, :type => :controller do
 
       stub_request(:post, "#{ENV['SIERRA_API_BASE_URL']}patrons/56789/holds/requests")
         .to_return(body: '', status: 201)
+
+      stub_request(:post, "#{ENV['SIERRA_API_BASE_URL']}patrons/55555/holds/requests")
+        .to_return(
+          body: JSON.generate({"description": "Request denied - already on hold for or checked out to you."}),
+          headers: {"Content-Type": "application/json"},
+          status: 400
+        )
     end
 
     it 'responds to /docs/patron with 200 and swagger doc' do
@@ -64,6 +71,22 @@ describe :app, :type => :controller do
       expect(response[:body]).to be_a(String)
       expect(JSON.parse(response[:body])).to be_a(Hash)
       expect(JSON.parse(response[:body])['statusCode']).to eq(201)
+    end
+
+    it 'responds to POST for duplicate hold request with 200' do
+      response = handle_event(
+        event: {
+          "path" => '/api/v0.1/on-site-hold-requests',
+          "httpMethod" => 'POST',
+          "body" => '{ "record": 12345, "patron": 55555 }'
+        },
+        context: {}
+      )
+
+      expect(response[:statusCode]).to eq(200)
+      expect(response[:body]).to be_a(String)
+      expect(JSON.parse(response[:body])).to be_a(Hash)
+      expect(JSON.parse(response[:body])['statusCode']).to eq(200)
     end
   end
 end

--- a/spec/lib_answers_email_spec.rb
+++ b/spec/lib_answers_email_spec.rb
@@ -83,4 +83,34 @@ describe LibAnswersEmail do
       end
     end
   end
+
+  describe 'email for duplicate hold' do
+    email = nil
+
+    before(:each) do
+      data = {
+        "record" => 10857004,
+        "patron" => 12345,
+        "docDeliveryData" => {
+          "date" => "date...",
+          "emailAddress" => "user@example.com",
+          "chapterTitle" => "Chapter One",
+          "startPage" => "100",
+          "endPage" => "150",
+          "author" => "Anonymous",
+          "issue" => "Summer 2017",
+          "volume" => "159",
+          "requestNotes" => "..."
+        }
+      }
+      hold_request = OnSiteHoldRequest.new(data)
+      hold_request.duplicate = true
+      email = LibAnswersEmail.new(hold_request)
+    end
+
+    it 'includes text indicating that hold is a duplicate' do
+      expected = 'Patron has made this EDD request for an item they already have on hold.'
+      expect(email.body(:text)).to include(expected)
+    end
+  end
 end

--- a/spec/lib_answers_email_spec.rb
+++ b/spec/lib_answers_email_spec.rb
@@ -110,7 +110,7 @@ describe LibAnswersEmail do
 
     it 'includes text indicating that hold is a duplicate' do
       expected = 'Patron has made this EDD request for an item they already have on hold.'
-      expect(email.body(:text)).to include(expected)
+      expect(email.body(:html)).to include(expected)
     end
   end
 end

--- a/spec/on_site_hold_request_spec.rb
+++ b/spec/on_site_hold_request_spec.rb
@@ -14,6 +14,12 @@ describe OnSiteHoldRequest do
 
     stub_request(:post, "#{ENV['SIERRA_API_BASE_URL']}patrons/12345/holds/requests")
       .to_return(body: '', status: 201)
+    stub_request(:post, "#{ENV['SIERRA_API_BASE_URL']}patrons/56789/holds/requests")
+      .to_return(
+        body: JSON.generate({"description": "Request denied - already on hold for or checked out to you."}),
+        headers: {"Content-Type": "application/json"},
+        status: 400
+      )
   end
 
   it 'instantiates an EDD OnSiteHoldRequest from params' do


### PR DESCRIPTION
This PR changes how the `SierraHoldAlreadyCreatedError` is handled. Now, a LibAnswers email is still sent with an extra line about the hold already existing.