### PR TITLE
Fix: Allow optional fields

### DIFF
--- a/lib/item.rb
+++ b/lib/item.rb
@@ -35,8 +35,11 @@ class Item
     var_field 852, 'h'
   end
 
+  ##
+  # Get associated bibs
   def bibs
     return @bibs unless @bibs.nil?
+    return [] if @data['bibIds'].nil? || !@data['bibIds'].is_a?(Array)
 
     @bibs = @data['bibIds'].map { |bib_id| Bib.by_id @data['nyplSource'], bib_id }
 

--- a/lib/on_site_hold_request.rb
+++ b/lib/on_site_hold_request.rb
@@ -53,7 +53,7 @@ class OnSiteHoldRequest
   def edd_email_differs_from_patron_email?
     return false unless is_edd?
 
-    edd_email != patron.emails.first
+    patron.emails.nil? || edd_email != patron.emails.first
   end
 
   def doc_delivery_data

--- a/spec/fixtures/item-10857004999-no-data.json
+++ b/spec/fixtures/item-10857004999-no-data.json
@@ -1,0 +1,296 @@
+{
+  "data": {
+    "nyplSource": "sierra-nypl",
+    "id": "10857004999",
+    "nyplType": "item",
+    "updatedDate": "2017-06-12T02:26:53-04:00",
+    "createdDate": "2009-02-03T18:43:49-05:00",
+    "deletedDate": null,
+    "deleted": false,
+    "location": {
+      "code": "mal82",
+      "name": "SASB M1 - General Research - Room 315"
+    },
+    "status": {
+      "code": "-",
+      "display": "AVAILABLE",
+      "duedate": null
+    },
+    "barcode": "33433110638107",
+    "callNumber": "|hJFE 00-4013",
+    "itemType": null,
+    "fixedFields": {
+      "57": {
+        "label": "BIB HOLD",
+        "value": false,
+        "display": null
+      },
+      "58": {
+        "label": "Copy No.",
+        "value": 1,
+        "display": null
+      },
+      "59": {
+        "label": "Item Code 1",
+        "value": "0",
+        "display": null
+      },
+      "60": {
+        "label": "Item Code 2",
+        "value": "-",
+        "display": null
+      },
+      "61": {
+        "label": "Item Type",
+        "value": "55",
+        "display": "book, limited circ, MaRLI"
+      },
+      "62": {
+        "label": "Price",
+        "value": 0,
+        "display": null
+      },
+      "64": {
+        "label": "Checkout Location",
+        "value": 0,
+        "display": null
+      },
+      "70": {
+        "label": "Checkin Location",
+        "value": 0,
+        "display": null
+      },
+      "74": {
+        "label": "Item Use 3",
+        "value": 0,
+        "display": null
+      },
+      "76": {
+        "label": "Total Checkouts",
+        "value": 0,
+        "display": null
+      },
+      "77": {
+        "label": "Total Renewals",
+        "value": 0,
+        "display": null
+      },
+      "79": {
+        "label": "Location",
+        "value": "mal82",
+        "display": "SASB M1 - General Research - Room 315"
+      },
+      "80": {
+        "label": "Record Type",
+        "value": "i",
+        "display": null
+      },
+      "81": {
+        "label": "Record Number",
+        "value": "10857004",
+        "display": null
+      },
+      "83": {
+        "label": "Created Date",
+        "value": "2009-02-03T18:43:49Z",
+        "display": null
+      },
+      "84": {
+        "label": "Updated Date",
+        "value": "2017-06-12T02:26:53Z",
+        "display": null
+      },
+      "85": {
+        "label": "No. of Revisions",
+        "value": "13",
+        "display": null
+      },
+      "86": {
+        "label": "Agency",
+        "value": "1",
+        "display": null
+      },
+      "88": {
+        "label": "Status",
+        "value": "-",
+        "display": "AVAILABLE"
+      },
+      "93": {
+        "label": "Inhouse Use",
+        "value": 0,
+        "display": null
+      },
+      "94": {
+        "label": "Copy Use",
+        "value": 0,
+        "display": null
+      },
+      "97": {
+        "label": "Item Message",
+        "value": "-",
+        "display": null
+      },
+      "98": {
+        "label": "PDATE",
+        "value": "2015-02-26T15:34:12Z",
+        "display": null
+      },
+      "108": {
+        "label": "OPAC Message",
+        "value": "1",
+        "display": null
+      },
+      "109": {
+        "label": "Year-to-Date Circ",
+        "value": 0,
+        "display": null
+      },
+      "110": {
+        "label": "Last Year Circ",
+        "value": 0,
+        "display": null
+      },
+      "127": {
+        "label": "Item Agency",
+        "value": "33",
+        "display": "S.A. Schwarzman Bldg."
+      },
+      "161": {
+        "label": "VI Central",
+        "value": 0,
+        "display": null
+      },
+      "162": {
+        "label": "IR Dist Learn Same Site",
+        "value": "0",
+        "display": null
+      },
+      "264": {
+        "label": "Holdings Item Tag",
+        "value": "6",
+        "display": null
+      },
+      "265": {
+        "label": "Inherit Location",
+        "value": false,
+        "display": null
+      }
+    },
+    "varFields": [
+      {
+        "fieldTag": "a",
+        "marcTag": "949",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "JFE 00-4013"
+          },
+          {
+            "tag": "h",
+            "content": "1"
+          },
+          {
+            "tag": "i",
+            "content": "0"
+          },
+          {
+            "tag": "j",
+            "content": "-"
+          },
+          {
+            "tag": "k",
+            "content": "2"
+          },
+          {
+            "tag": "l",
+            "content": "$0.00"
+          },
+          {
+            "tag": "m",
+            "content": "0"
+          },
+          {
+            "tag": "n",
+            "content": "0"
+          },
+          {
+            "tag": "o",
+            "content": "0"
+          },
+          {
+            "tag": "p",
+            "content": "hg   "
+          },
+          {
+            "tag": "q",
+            "content": "-"
+          },
+          {
+            "tag": "r",
+            "content": "0"
+          },
+          {
+            "tag": "s",
+            "content": "0"
+          },
+          {
+            "tag": "t",
+            "content": ""
+          },
+          {
+            "tag": "u",
+            "content": "-"
+          },
+          {
+            "tag": "v",
+            "content": "0"
+          },
+          {
+            "tag": "w",
+            "content": "0"
+          },
+          {
+            "tag": "x",
+            "content": ".i17514022"
+          },
+          {
+            "tag": "y",
+            "content": "08-17-01"
+          },
+          {
+            "tag": "z",
+            "content": "10-31-08"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "33433110638107",
+        "subfields": null
+      },
+      {
+        "fieldTag": "c",
+        "marcTag": "852",
+        "ind1": "8",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "h",
+            "content": "JFE 00-4013"
+          }
+        ]
+      }
+    ]
+  },
+  "count": 1,
+  "totalCount": 0,
+  "statusCode": 200,
+  "debugInfo": []
+}

--- a/spec/fixtures/patron-6789-no-data.json
+++ b/spec/fixtures/patron-6789-no-data.json
@@ -1,0 +1,64 @@
+{
+  "data": {
+    "id": 6789,
+    "updatedDate": "2020-04-21T01:00:49Z",
+    "createdDate": "2020-04-21T01:00:37Z",
+    "deleted": false,
+    "suppressed": false,
+    "barCodes": [
+        "12345678901234"
+    ],
+    "expirationDate": "2022-04-01",
+    "birthDate": "1896-11-22",
+    "patronType": 10,
+    "patronCodes": {
+        "pcode1": "-",
+        "pcode2": "p",
+        "pcode3": 2,
+        "pcode4": 0
+    },
+    "homeLibraryCode": "lb",
+    "message": {
+        "code": "-",
+        "accountMessages": [
+        ]
+    },
+    "blockInfo": {
+        "code": "c"
+    },
+    "addresses": [
+        {
+            "lines": [
+                "476 Fifth Avenue",
+                "NEW YORK, NY 10018"
+            ],
+            "type": "a"
+        }
+    ],
+    "moneyOwed": 10.00,
+    "fixedFields": {
+      "43": {
+        "label": "Expiration Date",
+        "value": "2022-06-23T08:00:00Z"
+      },
+      "96": {
+        "label": "Money Owed",
+        "value": "1275.000000"
+      },
+      "123": {
+        "label": "Debit Balance",
+        "value": "0.000000"
+      },
+      "124": {
+        "label": "Current Item C",
+        "value": "0"
+      },
+      "47": {
+        "label": "Patron Type",
+        "value": "81"
+      }
+    },
+    "varFields": [
+    ]
+  }
+}

--- a/spec/lib_answers_email_spec.rb
+++ b/spec/lib_answers_email_spec.rb
@@ -113,4 +113,49 @@ describe LibAnswersEmail do
       expect(email.body(:html)).to include(expected)
     end
   end
+
+  describe 'patron, item with missing fields'  do
+    email = nil
+
+    before(:each) do
+
+      stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}patrons/6789")
+        .to_return(body: File.read('./spec/fixtures/patron-6789-no-data.json'))
+      stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}items/sierra-nypl/10857004999")
+        .to_return(body: File.read('./spec/fixtures/item-10857004999-no-data.json'))
+
+      data = {
+        "record" => 10857004999,
+        "patron" => 6789,
+        "docDeliveryData" => {
+          "date" => "date...",
+          "emailAddress" => "user@example.com",
+          "chapterTitle" => "Chapter One",
+          "startPage" => "100",
+          "endPage" => "150",
+          "author" => "Anonymous",
+          "issue" => "Summer 2017",
+          "volume" => "159",
+          "requestNotes" => "..."
+        }
+      }
+      hold_request = OnSiteHoldRequest.new(data)
+      email = LibAnswersEmail.new(hold_request)
+    end
+
+    it 'includes empty Email field' do
+      expected = "Patron Email: \n"
+      expect(email.body(:text)).to include(expected)
+    end
+
+    it 'includes empty Name field' do
+      expected = "Patron Name: \n"
+      expect(email.body(:text)).to include(expected)
+    end
+
+    it 'includes empty title field' do
+      expected = "Item Title: \n"
+      expect(email.body(:text)).to include(expected)
+    end
+  end
 end


### PR DESCRIPTION
Fixes bug where missing email in patron account broke LibAnswers email
generation. Fixes this category of issue for many other fields. In
general, allows strictly optional data (like barcodes, bib data) to be
rendered as empty strings if they don't exist.