### PR TITLE
Change on-site edd pickup from myedd to paedd

### DIFF
--- a/lib/lib_answers_email.rb
+++ b/lib/lib_answers_email.rb
@@ -103,7 +103,7 @@ class LibAnswersEmail
     case @hold_request.item.location_code[(0...2)]
     when 'ma'
       email = location_email_mapping['SASB']
-    when 'my'
+    when 'pa', 'my' # Note 'my' is being deprecated
       email = location_email_mapping['LPA']
     when 'sc'
       email = location_email_mapping['SC']
@@ -131,7 +131,7 @@ class LibAnswersEmail
     case @hold_request.item.location_code[(0...2)]
     when 'ma'
       emails = ENV['LIB_ANSWERS_EMAIL_SASB_BCC'] || ''
-    when 'my'
+    when 'pa', 'my' # Note 'my' is being deprecated
       emails = ENV['LIB_ANSWERS_EMAIL_LPA_BCC'] || ''
     when 'sc'
       emails = ENV['LIB_ANSWERS_EMAIL_SC_BCC'] || ''

--- a/lib/on_site_hold_request.rb
+++ b/lib/on_site_hold_request.rb
@@ -86,8 +86,8 @@ class OnSiteHoldRequest
       case item.location_code[(0...2)]
       when 'ma'
         'maedd'
-      when 'my'
-        'myedd'
+      when 'pa', 'my' # Note 'my' is being deprecated
+        'paedd'
       when 'sc'
         'scedd'
       end

--- a/spec/fixtures/bib-10005886.json
+++ b/spec/fixtures/bib-10005886.json
@@ -1,0 +1,493 @@
+{
+  "data": {
+    "id": "10005886",
+    "nyplSource": "sierra-nypl",
+    "nyplType": "bib",
+    "updatedDate": "2023-07-17T14:57:14-04:00",
+    "createdDate": "2008-12-13T15:56:26-05:00",
+    "deletedDate": null,
+    "deleted": false,
+    "locations": [
+      {
+        "code": "scd",
+        "name": "Schomburg Center - Manuscripts & Archives"
+      },
+      {
+        "code": "pam32",
+        "name": "Performing Arts Research Collections - Music"
+      }
+    ],
+    "suppressed": false,
+    "lang": {
+      "code": "eng",
+      "name": "English"
+    },
+    "title": "Aïda : an opera in four acts",
+    "author": "Verdi, Giuseppe, 1813-1901.",
+    "materialType": {
+      "code": "a  ",
+      "value": "BOOK/TEXT"
+    },
+    "bibLevel": {
+      "code": "m",
+      "value": "MONOGRAPH"
+    },
+    "publishYear": 1900,
+    "catalogDate": "2000-12-15",
+    "country": {
+      "code": "nyu",
+      "name": "New York (State)"
+    },
+    "normTitle": "aïda an opera in four acts",
+    "normAuthor": "verdi giuseppe 1813 1901",
+    "standardNumbers": [],
+    "controlNumber": "NYPG005000028-B",
+    "fixedFields": {
+      "24": {
+        "label": "Language",
+        "value": "eng",
+        "display": "English"
+      },
+      "25": {
+        "label": "Skip",
+        "value": "0",
+        "display": null
+      },
+      "26": {
+        "label": "Location",
+        "value": "multi",
+        "display": null
+      },
+      "27": {
+        "label": "",
+        "value": "2",
+        "display": null
+      },
+      "28": {
+        "label": "Cat. Date",
+        "value": "2000-12-15",
+        "display": null
+      },
+      "29": {
+        "label": "Bib Level",
+        "value": "m",
+        "display": "MONOGRAPH"
+      },
+      "30": {
+        "label": "Material Type",
+        "value": "a  ",
+        "display": "BOOK/TEXT"
+      },
+      "31": {
+        "label": "Bib Code 3",
+        "value": "-",
+        "display": null
+      },
+      "80": {
+        "label": "Record Type",
+        "value": "b",
+        "display": null
+      },
+      "81": {
+        "label": "Record Number",
+        "value": "10005886",
+        "display": null
+      },
+      "83": {
+        "label": "Created Date",
+        "value": "2008-12-13T15:56:26Z",
+        "display": null
+      },
+      "84": {
+        "label": "Updated Date",
+        "value": "2023-07-17T14:57:14Z",
+        "display": null
+      },
+      "85": {
+        "label": "No. of Revisions",
+        "value": "19",
+        "display": null
+      },
+      "86": {
+        "label": "Agency",
+        "value": "1",
+        "display": null
+      },
+      "89": {
+        "label": "Country",
+        "value": "nyu",
+        "display": "New York (State)"
+      },
+      "98": {
+        "label": "",
+        "value": "2021-11-05T00:28:58Z",
+        "display": null
+      },
+      "107": {
+        "label": "MARC Type",
+        "value": " ",
+        "display": null
+      }
+    },
+    "varFields": [
+      {
+        "fieldTag": "a",
+        "marcTag": "100",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Verdi, Giuseppe,"
+          },
+          {
+            "tag": "d",
+            "content": "1813-1901."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Ghislanzoni, Antonio,"
+          },
+          {
+            "tag": "d",
+            "content": "1824-1893."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Operas"
+          },
+          {
+            "tag": "v",
+            "content": "Librettos."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "655",
+        "ind1": " ",
+        "ind2": "7",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Librettos."
+          },
+          {
+            "tag": "2",
+            "content": "aat"
+          }
+        ]
+      },
+      {
+        "fieldTag": "l",
+        "marcTag": "035",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "NNSZ00507100"
+          }
+        ]
+      },
+      {
+        "fieldTag": "l",
+        "marcTag": "035",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "(WaOLN)nyp0205876"
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "On cover: Metropolitan Opera House. Grand opera libretto."
+          }
+        ]
+      },
+      {
+        "fieldTag": "o",
+        "marcTag": "001",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "NYPG005000028-B",
+        "subfields": null
+      },
+      {
+        "fieldTag": "p",
+        "marcTag": "260",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "New York :"
+          },
+          {
+            "tag": "b",
+            "content": "F. Rullman,"
+          },
+          {
+            "tag": "c",
+            "content": "[190-?]"
+          }
+        ]
+      },
+      {
+        "fieldTag": "q",
+        "marcTag": "852",
+        "ind1": "8",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "h",
+            "content": "Sc Rare F 84-6"
+          }
+        ]
+      },
+      {
+        "fieldTag": "q",
+        "marcTag": "852",
+        "ind1": "8",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "h",
+            "content": "*MZ (Verdi, G. Aida)"
+          }
+        ]
+      },
+      {
+        "fieldTag": "r",
+        "marcTag": "300",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "39 p. ;"
+          },
+          {
+            "tag": "c",
+            "content": "26 cm."
+          }
+        ]
+      },
+      {
+        "fieldTag": "t",
+        "marcTag": "245",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Aïda :"
+          },
+          {
+            "tag": "b",
+            "content": "an opera in four acts /"
+          },
+          {
+            "tag": "c",
+            "content": "music by Giuseppe Verdi ;book by Antonio Ghizlandoni."
+          }
+        ]
+      },
+      {
+        "fieldTag": "v",
+        "marcTag": "959",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": ".b10059155"
+          },
+          {
+            "tag": "b",
+            "content": "07-18-08"
+          },
+          {
+            "tag": "c",
+            "content": "07-29-91"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "856",
+        "ind1": "4",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "u",
+            "content": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Aïda+:+an+opera+in+four+acts+/&Site=SCHRB&CallNumber=Sc+Rare+F+84-6&Author=Verdi,+Giuseppe,&ItemPlace=New+York+:&ItemPublisher=F.+Rullman,&Date=[190-?]&ItemInfo3=https://catalog.nypl.org/record=b10005886&ReferenceNumber=b100058863&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433076159593&ItemISxN=i10003892x&Genre=Book-text&Location=Schomburg+Center"
+          },
+          {
+            "tag": "z",
+            "content": "Request Access to Special Collections Material"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "008",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "850618q19001909nyu           000 d eng dcam a ",
+        "subfields": null
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "005",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "20001116192511.1",
+        "subfields": null
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "040",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "NN"
+          },
+          {
+            "tag": "c",
+            "content": "NN"
+          },
+          {
+            "tag": "d",
+            "content": "WaOLN"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "041",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "eng"
+          },
+          {
+            "tag": "h",
+            "content": "ita"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "997",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "sm"
+          },
+          {
+            "tag": "a",
+            "content": "pm"
+          },
+          {
+            "tag": "b",
+            "content": "12-15-00"
+          },
+          {
+            "tag": "c",
+            "content": "m"
+          },
+          {
+            "tag": "d",
+            "content": "a"
+          },
+          {
+            "tag": "e",
+            "content": "-"
+          },
+          {
+            "tag": "f",
+            "content": "eng"
+          },
+          {
+            "tag": "g",
+            "content": "nyu"
+          },
+          {
+            "tag": "h",
+            "content": "0"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "910",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "RL"
+          }
+        ]
+      },
+      {
+        "fieldTag": "_",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "00000cam  2200253 a 4500",
+        "subfields": null
+      }
+    ]
+  }
+}

--- a/spec/fixtures/item-10003893.json
+++ b/spec/fixtures/item-10003893.json
@@ -1,0 +1,292 @@
+{
+  "data": {
+    "nyplSource": "sierra-nypl",
+    "bibIds": [
+      "10005886"
+    ],
+    "id": "10003893",
+    "nyplType": "item",
+    "updatedDate": "2023-07-17T11:50:27-04:00",
+    "createdDate": "2009-02-03T00:41:39-05:00",
+    "deletedDate": null,
+    "deleted": false,
+    "location": {
+      "code": "pam32",
+      "name": "Performing Arts Research Collections - Music"
+    },
+    "status": {
+      "code": "-",
+      "display": "AVAILABLE",
+      "duedate": null
+    },
+    "barcode": null,
+    "callNumber": "*MZ (Verdi, G. Aida)",
+    "itemType": null,
+    "fixedFields": {
+      "57": {
+        "label": "",
+        "value": "false",
+        "display": null
+      },
+      "58": {
+        "label": "Copy No.",
+        "value": "1",
+        "display": null
+      },
+      "59": {
+        "label": "Item Code 1",
+        "value": "0",
+        "display": null
+      },
+      "60": {
+        "label": "Item Code 2",
+        "value": "-",
+        "display": null
+      },
+      "61": {
+        "label": "Item Type",
+        "value": "2",
+        "display": "book non-circ"
+      },
+      "62": {
+        "label": "Price",
+        "value": "0.000000",
+        "display": null
+      },
+      "64": {
+        "label": "Checkout Location",
+        "value": "0",
+        "display": null
+      },
+      "70": {
+        "label": "Checkin Location",
+        "value": "0",
+        "display": null
+      },
+      "74": {
+        "label": "Item Use 3",
+        "value": "0",
+        "display": null
+      },
+      "76": {
+        "label": "Total Checkouts",
+        "value": "0",
+        "display": null
+      },
+      "77": {
+        "label": "Total Renewals",
+        "value": "0",
+        "display": null
+      },
+      "79": {
+        "label": "Location",
+        "value": "pam32",
+        "display": "Performing Arts Research Collections - Music"
+      },
+      "80": {
+        "label": "Record Type",
+        "value": "i",
+        "display": null
+      },
+      "81": {
+        "label": "Record Number",
+        "value": "10003893",
+        "display": null
+      },
+      "83": {
+        "label": "Created Date",
+        "value": "2009-02-03T00:41:39Z",
+        "display": null
+      },
+      "84": {
+        "label": "Updated Date",
+        "value": "2023-07-17T11:50:27Z",
+        "display": null
+      },
+      "85": {
+        "label": "No. of Revisions",
+        "value": "10",
+        "display": null
+      },
+      "86": {
+        "label": "Agency",
+        "value": "1",
+        "display": null
+      },
+      "88": {
+        "label": "Status",
+        "value": "-",
+        "display": "AVAILABLE"
+      },
+      "93": {
+        "label": "Inhouse Use",
+        "value": "0",
+        "display": null
+      },
+      "94": {
+        "label": "Copy Use",
+        "value": "0",
+        "display": null
+      },
+      "97": {
+        "label": "Item Message",
+        "value": "-",
+        "display": null
+      },
+      "98": {
+        "label": "",
+        "value": "2015-01-05T18:56:25Z",
+        "display": null
+      },
+      "108": {
+        "label": "OPAC Message",
+        "value": "1",
+        "display": "USE IN LIBRARY"
+      },
+      "109": {
+        "label": "Year-to-Date Circ",
+        "value": "0",
+        "display": null
+      },
+      "110": {
+        "label": "Last Year Circ",
+        "value": "0",
+        "display": null
+      },
+      "127": {
+        "label": "Item Agency",
+        "value": "32",
+        "display": "LPA"
+      },
+      "161": {
+        "label": "VI Central",
+        "value": "0",
+        "display": null
+      },
+      "162": {
+        "label": "IR Dist Learn Same Site",
+        "value": "0",
+        "display": null
+      },
+      "264": {
+        "label": "Holdings Item Tag",
+        "value": "6",
+        "display": null
+      },
+      "265": {
+        "label": "Inherit Location",
+        "value": "false",
+        "display": null
+      },
+      "306": {
+        "label": "Sticky Status",
+        "value": "",
+        "display": null
+      }
+    },
+    "varFields": [
+      {
+        "fieldTag": "a",
+        "marcTag": "949",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "*MZ (Verdi, G. Aida)"
+          },
+          {
+            "tag": "h",
+            "content": "2"
+          },
+          {
+            "tag": "i",
+            "content": "0"
+          },
+          {
+            "tag": "j",
+            "content": "-"
+          },
+          {
+            "tag": "k",
+            "content": "2"
+          },
+          {
+            "tag": "l",
+            "content": "$0.00"
+          },
+          {
+            "tag": "m",
+            "content": "0"
+          },
+          {
+            "tag": "n",
+            "content": "0"
+          },
+          {
+            "tag": "o",
+            "content": "0"
+          },
+          {
+            "tag": "p",
+            "content": "pm   "
+          },
+          {
+            "tag": "q",
+            "content": "-"
+          },
+          {
+            "tag": "r",
+            "content": "0"
+          },
+          {
+            "tag": "s",
+            "content": "0"
+          },
+          {
+            "tag": "t",
+            "content": ""
+          },
+          {
+            "tag": "u",
+            "content": "-"
+          },
+          {
+            "tag": "v",
+            "content": "0"
+          },
+          {
+            "tag": "w",
+            "content": "0"
+          },
+          {
+            "tag": "x",
+            "content": ".i11820548"
+          },
+          {
+            "tag": "y",
+            "content": "05-10-00"
+          },
+          {
+            "tag": "z",
+            "content": "10-29-08"
+          }
+        ]
+      },
+      {
+        "fieldTag": "c",
+        "marcTag": "852",
+        "ind1": "8",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "h",
+            "content": "*MZ (Verdi, G. Aida)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/spec/on_site_hold_request_spec.rb
+++ b/spec/on_site_hold_request_spec.rb
@@ -12,6 +12,12 @@ describe OnSiteHoldRequest do
     stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/14468362")
       .to_return(body: File.read('./spec/fixtures/bib-14468362.json'))
 
+    # LPA item fixture:
+    stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}items/sierra-nypl/10003893")
+      .to_return(body: File.read('./spec/fixtures/item-10003893.json'))
+    stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/10005886")
+      .to_return(body: File.read('./spec/fixtures/bib-10005886.json'))
+
     stub_request(:post, "#{ENV['SIERRA_API_BASE_URL']}patrons/12345/holds/requests")
       .to_return(body: '', status: 201)
     stub_request(:post, "#{ENV['SIERRA_API_BASE_URL']}patrons/56789/holds/requests")
@@ -48,6 +54,21 @@ describe OnSiteHoldRequest do
     expect(hold_request.item).to be_a(Item)
     expect(hold_request.item.id).to eq("10857004")
     expect(hold_request.pickup_location).to eq("maedd")
+  end
+
+  it 'routes LPA materials to paedd' do
+    params = {
+      "record" => "10003893",
+      "patron" => "12345",
+      "docDeliveryData" => {
+        "emailAddress" => "user@example.com"
+      }
+    }
+    hold_request = OnSiteHoldRequest.create params
+    expect(hold_request).to be_a(OnSiteHoldRequest)
+    expect(hold_request.item).to be_a(Item)
+    expect(hold_request.item.id).to eq("10003893")
+    expect(hold_request.pickup_location).to eq("paedd")
   end
 
   it 'detects EDD email that differs from patron email' do


### PR DESCRIPTION
Because they're splitting LPA locations from my* to lp* and pa*, we need to change the on-site EDD pickupLocation for LPA materials from myedd to paedd. I assume that no circ materials are ever EDD requestable given the low item types in the on-site EDD criteria.

https://jira.nypl.org/browse/SCC-3657